### PR TITLE
Link the Chrome Web Store listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Repository documentation and artwork only. The packaged extension is unchanged.
 
 ### Added
 
+- Install links to the published Chrome Web Store listing: an Add to Chrome button under
+  the tagline, a store-version badge in place of the GitHub release badge, and an `Install`
+  section that leads with the store and keeps loading unpacked as a subsection for
+  development. The listing URL is also recorded in `store/LISTING.md`.
 - README artwork in `media/`, rendered by `scripts/make-readme-media.js` (`npm run media`):
   a banner reusing the mark and gradient from the store tiles, and the two store
   screenshots cropped to their content. The store PNGs stay 1280x800 for the dashboard.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/tsvb/post-peek/releases"><img
-     alt="Latest release" src="https://img.shields.io/github/v/release/tsvb/post-peek?style=flat-square&color=1d9bf0&label=release"></a>
+  <a href="https://chromewebstore.google.com/detail/nkjjgbkfdaembjfandhlgfijhbigblnn"><img
+     alt="Chrome Web Store" src="https://img.shields.io/chrome-web-store/v/nkjjgbkfdaembjfandhlgfijhbigblnn?style=flat-square&color=1d9bf0&label=chrome%20web%20store"></a>
   <a href="LICENSE"><img
      alt="MIT license" src="https://img.shields.io/badge/license-MIT-1d9bf0?style=flat-square"></a>
   <img alt="Manifest V3" src="https://img.shields.io/badge/Chrome-Manifest%20V3-1d9bf0?style=flat-square">
@@ -17,6 +17,11 @@
   <b>Read one X post and leave.</b><br>
   A Chrome (Manifest V3) extension that opens x.com and twitter.com post links in a popup
   instead of sending you to the full site.
+</p>
+
+<p align="center">
+  <a href="https://chromewebstore.google.com/detail/nkjjgbkfdaembjfandhlgfijhbigblnn"><img
+     alt="Add to Chrome" src="https://img.shields.io/badge/Add%20to%20Chrome-1d9bf0?style=for-the-badge&logo=googlechrome&logoColor=white"></a>
 </p>
 
 <table>
@@ -48,7 +53,12 @@ it is the better fit there. See [Credit](#credit).
 - Settings stay on your device (`chrome.storage.local`, never synced).
 - No data collection. See [PRIVACY.md](PRIVACY.md).
 
-## Install from source
+## Install
+
+[**Add to Chrome from the Chrome Web Store**](https://chromewebstore.google.com/detail/nkjjgbkfdaembjfandhlgfijhbigblnn) - the reviewed build, kept up to date
+by Chrome.
+
+### From source
 
 1. Open `chrome://extensions`, enable **Developer mode**, click **Load unpacked**, and pick this folder.
 2. Serve this folder over HTTP and open the test page, for example:

--- a/store/LISTING.md
+++ b/store/LISTING.md
@@ -115,3 +115,4 @@ until they are done:
 
 - Homepage URL: https://github.com/tsvb/post-peek
 - Support URL: https://github.com/tsvb/post-peek/issues
+- Published listing: https://chromewebstore.google.com/detail/nkjjgbkfdaembjfandhlgfijhbigblnn


### PR DESCRIPTION
Follow-up to #1, which merged before this commit was pushed. Single commit, README and docs only.

After #1 the README still had no install path except loading unpacked, which reads as a developer-only project. This adds:

- An **Add to Chrome** button under the tagline, pointing at the [published listing](https://chromewebstore.google.com/detail/nkjjgbkfdaembjfandhlgfijhbigblnn).
- An `## Install` section that leads with the store, keeping the unpacked-load steps as a `### From source` subsection.
- The store's published version in the badge row, in place of the GitHub release badge. Showing both put two version numbers side by side, and the store's is the one users actually install. Shields reads it live from the listing, so it tracks releases without anyone editing the README.
- The listing URL recorded in `store/LISTING.md` next to the homepage and support URLs.

## Verification

Every badge was checked by fetching the image GitHub actually serves, through its own camo proxy, and reading the returned SVG:

| Badge | HTTP | SVG reads |
|---|---|---|
| Chrome Web Store | 200 | `chrome web store: v1.1.4` |
| Add to Chrome | 200 | `ADD TO CHROME` + Chrome logo |
| License | 200 | `license: MIT` |
| Manifest | 200 | `Chrome: Manifest V3` |
| Tracking | 200 | `tracking: none` |

The store badge returning a real version rather than `invalid` confirms shields can reach the listing, which also independently confirms the item ID. The hex in each camo URL was decoded to check GitHub is proxying exactly the intended URLs, `%20` encoding intact.

`npm test` passes, 16/16. The packaged extension is untouched.

Note: `chromewebstore.google.com` is blocked by this sandbox's egress, so the listing page was never loaded directly here — shields loaded it and got a version back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDFNuZzJUnTZ3dHzzfsf9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDFNuZzJUnTZ3dHzzfsf9U)_